### PR TITLE
Attach authors to with_tag

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -309,6 +309,7 @@ class GovUkContentApi < Sinatra::Application
     end
     
     results = map_artefacts_and_add_editions(artefacts)
+    results = attach_authors(results)
     @result_set = FakePaginatedResultSet.new(results)
 
     render :rabl, :with_tag, format: "json"
@@ -406,6 +407,16 @@ class GovUkContentApi < Sinatra::Application
     else
       nil
     end
+  end
+  
+  def attach_authors(artefacts)
+    artefacts.map do |artefact|
+      author = get_artefact_author(artefact)
+      artefact.author_name = author.title
+      artefact.author_slug = author.slug
+      artefact
+    end
+    artefacts
   end
   
   def map_editions_with_artefacts(editions)

--- a/lib/artefact.rb
+++ b/lib/artefact.rb
@@ -6,6 +6,8 @@ require "govspeak"
 
 module ContentApiArtefactExtensions
   extend ActiveSupport::Concern
+  
+  attr_accessor :author_name, :author_slug
 
   included do
     attr_accessor :edition, :licence, :places, :assets, :country, :extra_related_artefacts

--- a/views/with_tag.rabl
+++ b/views/with_tag.rabl
@@ -8,7 +8,11 @@ child(:results => "results") do
   node :details do |artefact|
     h = {
       "description" => artefact.description,
-      "excerpt" => artefact.excerpt
+      "excerpt" => artefact.excerpt,
+      "author" => {
+        "name" => artefact.author_name,
+        "slug" => artefact.author_slug
+      }
     }
     [:role].each do |field|
       h[field] = artefact.edition.send(field) if artefact.edition.respond_to?(field)


### PR DESCRIPTION
This adds authors to the `with_tag` view, so we can see who has written what on the `/news` page for example
