### PR TITLE
Add related artefacts action

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -314,6 +314,29 @@ class GovUkContentApi < Sinatra::Application
 
     render :rabl, :with_tag, format: "json"
   end
+  
+  get "/related.json" do
+    kv = params.first
+    type = kv[0]
+    item = kv[1]
+    
+    allowed_types = ['course']
+    
+    unless allowed_types.include?(type)
+      custom_404
+    else    
+      editions = Edition.where(type => item, :state => 'published')
+    
+      custom_404 if editions.count == 0
+    
+      @description = "All items with #{type} #{item}"
+    
+      @results = map_editions_with_artefacts(editions)
+      @result_set = FakePaginatedResultSet.new(@results)
+    
+      render :rabl, :with_tag, format: "json"
+    end
+  end
 
   get "/licences.json" do
     licence_ids = (params[:ids] || '').split(',')


### PR DESCRIPTION
On pages such as courses, we want to be able to pull all the course instances with that course as a course. This action allows us to do this. Will also require some work to gds-api-adapters, which I'll get in another PR.
