### PR TITLE
Only attach assets if edition is published

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -471,7 +471,9 @@ class GovUkContentApi < Sinatra::Application
         else
           a = artefact
         end
-        attach_assets(a, :image) if a.edition.is_a?(PersonEdition)
+        unless a.nil?
+          attach_assets(a, :image) if a.edition.is_a?(PersonEdition)
+        end
         a
       end
 


### PR DESCRIPTION
Content API craps out if the Artefact exists, but the Edition is unpublished.
