### PR TITLE
Fix Sam

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -613,7 +613,7 @@ class GovUkContentApi < Sinatra::Application
       artefact.edition = if version_number
         Edition.where(panopticon_id: artefact.id, version_number: version_number).first
       else
-        Edition.where(panopticon_id: artefact.id, state: 'published').first ||
+        Edition.where(panopticon_id: artefact.id, state: 'published').last ||
           Edition.where(panopticon_id: artefact.id).first
       end
     end


### PR DESCRIPTION
We changed Sam's job title, and it was showing up fine [here](http://quirkafleeg.info/team), but not [here](http://quirkafleeg.info/team/sam-pikesley). I think this is because the imported data is staying as published, even thoughthere's a newer published version, so I've changed the `attach_publisher_edition` method to get the last published version, rather than the first.
