### PR TITLE
Make created at date for artefact always be the artefact's creation date

### DIFF
--- a/lib/timestamp_helpers.rb
+++ b/lib/timestamp_helpers.rb
@@ -16,8 +16,6 @@ module TimestampHelpers
   
   # Returns the created date that should be presented to the user
   def presented_created_date(artefact)
-    updated_options = [artefact.created_at]
-    updated_options << artefact.edition.created_at if artefact.edition
-    updated_options.compact.max
+    artefact.created_at
   end
 end


### PR DESCRIPTION
We've just discovered that created_at reflects the editions created at date, rather than the editions. We don't want this, so this PR fixes that.
