### PR TITLE
Get all course instances, regardless of published status

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -360,7 +360,7 @@ class GovUkContentApi < Sinatra::Application
   
   get "/course-instance.json" do    
     if params[:course] && params[:date]          
-      instance = CourseInstanceEdition.where(:state => "published", :course => params[:course], :date => {:$gte => Date.parse(params[:date]), :$lt => (Date.parse(params[:date]) + 1.day) })
+      instance = CourseInstanceEdition.where(:course => params[:course], :date => {:$gte => Date.parse(params[:date]), :$lt => (Date.parse(params[:date]) + 1.day) })
       
       custom_404 if instance.count == 0
       


### PR DESCRIPTION
Fixes the issue with course instances not previewing.

Needed for theodi/shared#126
