### PR TITLE
Fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ after_success:
 branches:
   except:
   - CURRENT
+services:
+  - mongodb
 notifications:
   irc:
     channels:


### PR DESCRIPTION
Weirdly, we now have to specify mongodb as a service, even though previous tests have been fine. This should pass though.
