### PR TITLE
Return to alphagov govuk_content_models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'dotenv'
 
 gem 'sinatra-cross_origin'
 
-gem "govuk_content_models", github: 'theodi/govuk_content_models', branch: 'feature-lambda-format-validator'
+gem 'govuk_content_models', '6.0.6'
+
 if ENV['CONTENT_MODELS_DEV']
   gem "odi_content_models", path: '../odi_content_models'
 else
@@ -25,7 +26,7 @@ end
 
 # Pinning mongo to prevent bundler downgrading it in order to upgrade bson
 # (as seen in 680d3e9ab7)
-gem 'mongo', '>= 1.6.2'
+gem 'mongo', '>= 1.7.1'
 
 gem 'gds-sso', '3.0.1'
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,4 @@
 GIT
-  remote: git://github.com/theodi/govuk_content_models.git
-  revision: d2c8536da24a9ef003e1eb40f5bac2074dfa478b
-  branch: feature-lambda-format-validator
-  specs:
-    govuk_content_models (5.10.0)
-      bson_ext
-      differ
-      gds-api-adapters
-      gds-sso (>= 3.0.0, < 4.0.0)
-      govspeak (>= 1.0.1, < 2.0.0)
-      mongoid (~> 2.4.10)
-      plek
-      state_machine
-
-GIT
   remote: git://github.com/theodi/odi_content_models.git
   revision: 67550837282f8915384b0b74ff0d8b722271a0bf
   specs:
@@ -66,9 +51,9 @@ GEM
       mail (> 2.2.5)
       mime-types
       xml-simple
-    bson (1.6.4)
-    bson_ext (1.6.4)
-      bson (~> 1.6.4)
+    bson (1.9.2)
+    bson_ext (1.9.2)
+      bson (~> 1.9.2)
     builder (3.0.4)
     ci_reporter (1.7.0)
       builder (>= 2.1.2)
@@ -101,6 +86,15 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
+    govuk_content_models (6.0.6)
+      bson_ext
+      differ
+      gds-api-adapters
+      gds-sso (>= 3.0.0, < 4.0.0)
+      govspeak (>= 1.0.1, < 2.0.0)
+      mongoid (~> 2.5)
+      plek
+      state_machine
     hashie (1.2.0)
     hike (1.2.1)
     htmlentities (4.3.1)
@@ -127,11 +121,11 @@ GEM
     minitest (3.4.0)
     mocha (0.12.4)
       metaclass (~> 0.0.1)
-    mongo (1.6.2)
-      bson (~> 1.6.2)
-    mongoid (2.4.12)
+    mongo (1.9.2)
+      bson (~> 1.9.2)
+    mongoid (2.8.1)
       activemodel (~> 3.1)
-      mongo (<= 1.6.2)
+      mongo (~> 1.9)
       tzinfo (~> 0.3.22)
     multi_json (1.3.7)
     multipart-post (1.1.5)
@@ -255,12 +249,12 @@ DEPENDENCIES
   foreman
   gds-api-adapters (= 7.2.0)
   gds-sso (= 3.0.1)
-  govuk_content_models!
+  govuk_content_models (= 6.0.6)
   kaminari (= 0.14.1)
   link_header (= 0.0.5)
   minitest (= 3.4.0)
   mocha (= 0.12.4)
-  mongo (>= 1.6.2)
+  mongo (>= 1.7.1)
   odi_content_models!
   odidown!
   omniauth-gds (= 0.0.3)


### PR DESCRIPTION
First part of upgrade all the things, let's get back to using the main alphagov content_models.

This PR gets us to govuk_content_models 6.0.6. I had to upgrade some mongo things as well so I would advise we merge this in the morning @pikesley so we can reboot anything that needs it.
