### PR TITLE
Check tags include tags, rather than looking for an exact match

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -284,7 +284,7 @@ class GovUkContentApi < Sinatra::Application
   #    - all artefacts in the Crime section, with any curated ones first
   get "/with_tag.json" do
     expires DEFAULT_CACHE_TIME
-    
+
     @statsd_scope = 'request.with_tag'
 
     unless params[:tag].blank?
@@ -412,7 +412,7 @@ class GovUkContentApi < Sinatra::Application
       possible_tags = Tag.where(tag_id: params[:tag]).to_a
       custom_404 if possible_tags.count == 0
 
-      artefact = Artefact.live.where(tag_ids: [@role, params[:tag]]).order_by(:created_at.desc).first
+      artefact = Artefact.live.where(tag_ids: { "$all" => [@role, params[:tag]] }).order_by(:created_at.desc).first
     end
     get_artefact(artefact.slug, params)
   end


### PR DESCRIPTION
Since we had the new tagging regime introduced in https://github.com/theodi/panopticon/pull/93, we've been adding extra tags to conent. `latest.json` looks for an exact match, so the homepage hasn't been updating. I've tweaked the code now so it checks all the tags are included, rather than looking for an exact match.
