### PR TITLE
Show course instances when there are older drafts

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -439,11 +439,11 @@ class GovUkContentApi < Sinatra::Application
     expires DEFAULT_CACHE_TIME
 
     if params[:course] && params[:date]
-      instance = CourseInstanceEdition.where(:course => params[:course], :date => {:$gte => Date.parse(params[:date]), :$lt => (Date.parse(params[:date]) + 1.day) })
+      instance = CourseInstanceEdition.where(:course => params[:course], :state => "published", :date => {:$gte => Date.parse(params[:date]), :$lt => (Date.parse(params[:date]) + 1.day) })
 
       custom_404 if instance.count == 0
 
-      get_artefact(instance.first.slug, { edition: params[:edition] })
+      get_artefact(instance.last.slug, { edition: params[:edition] })
     else
       custom_404
     end

--- a/test/requests/course_instance_request_test.rb
+++ b/test/requests/course_instance_request_test.rb
@@ -26,6 +26,7 @@ class CourseInstanceRequest < GovUkContentApiTest
       @edition2 = FactoryGirl.create(:course_instance_edition,
         slug: "this-is-a-course-#{@date_str}",
         panopticon_id: @artefact.id,
+        state: "draft",
         course: "this-is-a-course",
         description: "new description",
         version_number: 2,


### PR DESCRIPTION
It seems course instances aren't showing when there are multiple drafts in existence. This fixes things.