### PR TITLE
redirect web_url for tag from browse to tags

### DIFF
--- a/lib/url_helper.rb
+++ b/lib/url_helper.rb
@@ -59,7 +59,7 @@ class URLHelper
   end
 
   def with_tag_web_url(tag)
-    public_web_url("/browse/#{tag.tag_id}")
+    public_web_url("/tags/#{tag.tag_id}")
   end
 
   def artefacts_url(page = nil)

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -183,7 +183,7 @@ class ArtefactRequestTest < GovUkContentApiTest
       assert_equal "section", tag_info["details"]["type"]
       # Temporary hack until the browse pages are rebuilt
       expected_section_slug = section[0]
-      assert_equal "#{public_web_url}/browse/#{expected_section_slug}", tag_info["content_with_tag"]["web_url"]
+      assert_equal "#{public_web_url}/tags/#{expected_section_slug}", tag_info["content_with_tag"]["web_url"]
     end
   end
 

--- a/test/requests/tag_list_request_test.rb
+++ b/test/requests/tag_list_request_test.rb
@@ -31,7 +31,7 @@ class TagListRequestTest < GovUkContentApiTest
       tag = FactoryGirl.create(:tag, tag_id: 'crime')
       get "/tags.json"
       expected_id = "http://example.org/tags/sections/crime.json"
-      expected_url = "#{public_web_url}/browse/crime"
+      expected_url = "#{public_web_url}/tags/crime"
 
       JSON.parse(last_response.body)['results'].map do |result|
         if result["slug"] == "crime"

--- a/test/requests/tag_request_test.rb
+++ b/test/requests/tag_request_test.rb
@@ -17,7 +17,7 @@ class TagRequestTest < GovUkContentApiTest
       assert_equal "http://example.org/tags/sections/good-tag.json", response["id"]
       assert_equal nil, response["web_url"]
       assert_equal(
-        "#{public_web_url}/browse/good-tag",
+        "#{public_web_url}/tags/good-tag",
         response["content_with_tag"]["web_url"]
       )
     end
@@ -71,7 +71,7 @@ class TagRequestTest < GovUkContentApiTest
 
       assert last_response.ok?
       response = JSON.parse(last_response.body)
-      assert_equal "#{public_web_url}/browse/crime/batman", response["content_with_tag"]["web_url"]
+      assert_equal "#{public_web_url}/tags/crime/batman", response["content_with_tag"]["web_url"]
     end
 
     describe "has a parent tag" do
@@ -93,7 +93,7 @@ class TagRequestTest < GovUkContentApiTest
           },
           "content_with_tag" => {
             "id" => "http://example.org/with_tag.json?section=crime-and-prison",
-            "web_url" => "#{public_web_url}/browse/crime-and-prison",
+            "web_url" => "#{public_web_url}/tags/crime-and-prison",
             "slug" => "crime-and-prison"
           },
           "parent" => nil,


### PR DESCRIPTION
Concerning theodi/frontend-www#365.

# What's changed
* Changing the public web url revealed via contentapi to use `tags` instead of `browse`.