### PR TITLE
Dockerizing...

### DIFF
--- a/mongoid.yml
+++ b/mongoid.yml
@@ -1,10 +1,10 @@
 development:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_content_development
   logger: true
   use_activesupport_time_zone: true
 test:
-  host: localhost
+  host: <%= ENV['MONGOID_HOST'] ||= "localhost" %>
   database: govuk_content_shared_test
   logger: false
   use_activesupport_time_zone: true


### PR DESCRIPTION
`MONGOID_HOST` sets hostname of mongo database, defaults `localhost`.