### PR TITLE
Show author even if archived

### DIFF
--- a/lib/artefact.rb
+++ b/lib/artefact.rb
@@ -46,7 +46,7 @@ module ContentApiArtefactExtensions
     @author_edition ||= begin
       if author
         artefact = Artefact.find_by_slug(author)
-        Edition.where(panopticon_id: artefact.id, state: 'published').first rescue nil
+        Edition.where(panopticon_id: artefact.id).first rescue nil
       else
         nil
       end

--- a/lib/presenters/artefact_author_presenter.rb
+++ b/lib/presenters/artefact_author_presenter.rb
@@ -8,6 +8,7 @@ class ArtefactAuthorPresenter
     {
       name: @author.title,
       slug: @author.slug,
+      state: @author.state,
       web_url: @url_helper.artefact_web_url(@author.artefact),
       tag_ids: @author.artefact.scoped_tag_ids
     }

--- a/test/requests/artefact_request_test.rb
+++ b/test/requests/artefact_request_test.rb
@@ -511,6 +511,35 @@ class ArtefactRequestTest < GovUkContentApiTest
     assert_equal 200, last_response.status
     assert_equal 'Barry Scott', parsed_response["author"]["name"]
     assert_equal 'barry-scott', parsed_response["author"]["slug"]
+    assert_equal 'published', parsed_response["author"]["state"]
+
+    assert parsed_response["author"]["tag_ids"].include?('writers')
+  end
+
+  it "should include author details even if the author has been archived" do
+    barry = FactoryGirl.create(:my_artefact, state: 'live', slug: 'barry-scott', name: "Barry Scott", kind: "person", person: ['writers'])
+    FactoryGirl.create(:person_edition,
+      title: barry.name,
+      slug: barry.slug,
+      panopticon_id: barry.id,
+      state: 'published')
+
+    artefact = FactoryGirl.create(:my_artefact, state: 'live', author: 'barry-scott')
+    FactoryGirl.create(:guide_edition,
+      slug: artefact.slug,
+      panopticon_id: artefact.id,
+      state: 'published')
+
+    barry.state = 'archived'
+    barry.save
+
+    get "/#{artefact.slug}.json"
+    parsed_response = JSON.parse(last_response.body)
+    assert_equal 200, last_response.status
+    assert_equal 'Barry Scott', parsed_response["author"]["name"]
+    assert_equal 'barry-scott', parsed_response["author"]["slug"]
+    assert_equal 'archived', parsed_response["author"]["state"]
+
     assert parsed_response["author"]["tag_ids"].include?('writers')
   end
 


### PR DESCRIPTION
This makes sure even archived authors show in the API. We can then show their names on the website, but without a link to their profile