### PR TITLE
Remove json csrf protection

### DIFF
--- a/govuk_content_api.rb
+++ b/govuk_content_api.rb
@@ -50,6 +50,7 @@ class GovUkContentApi < Sinatra::Application
 
   set :views, File.expand_path('views', File.dirname(__FILE__))
   set :show_exceptions, false
+  set :protection, :except => [:json_csrf]
 
   before do
     response.headers['Access-Control-Allow-Origin'] = "*"


### PR DESCRIPTION
This is because we’re on an old version of rack/protection. We need this for the image stuff